### PR TITLE
1.3.2 -- Rather than caching AssetName in fileName[], let's just use …

### DIFF
--- a/UpdateSpotlight.go
+++ b/UpdateSpotlight.go
@@ -17,13 +17,13 @@ import (
 	"./spotlight"
 )
 
-const version = "1.3.1"
+const version = "1.3.2"
 
 var assetBySize map[int64]map[string]string
 var toBeCopied map[string]bool
-var fileName map[string]string // Let's cache the filenames so we don't need to re-extract
 var photoData map[string]map[string]string
 var fileExt map[string]string
+var config spotlight.Config
 
 func main() {
 	fmt.Printf("UpdateSpotlight v%s -- by PJSoftware\n", version)
@@ -36,7 +36,6 @@ func main() {
 	defer logFile.Close()
 	log.SetOutput(logFile)
 
-	var config spotlight.Config
 	config.Init(exePath)
 
 	metadata := new(spotlight.MetaData)
@@ -62,29 +61,28 @@ func browseAssets(sourcePath string, width, height int, metadata *spotlight.Meta
 
 	assetBySize = make(map[int64]map[string]string)
 	toBeCopied = make(map[string]bool)
-	fileName = make(map[string]string)
 	fileExt = make(map[string]string)
 	photoData = make(map[string]map[string]string)
 
 	for _, file := range files {
-		assetPath := sourcePath + "/" + file.Name()
+		assetName := file.Name()
+		assetPath := sourcePath + "/" + assetName
 		if isWallpaper(assetPath, width, height) {
 			fileSize := file.Size()
 			if _, ok := assetBySize[fileSize]; !ok {
 				assetBySize[fileSize] = make(map[string]string)
 			}
-			assetBySize[fileSize][assetPath] = cryptoSum(assetPath)
-			toBeCopied[assetPath] = true
-			fileName[assetPath] = file.Name()
+			assetBySize[fileSize][assetName] = cryptoSum(assetPath)
+			toBeCopied[assetName] = true
 			for _, image := range metadata.Images {
 				if image.FileSize() == fileSize {
 					// the chances of anything coming from Mars are a million to one
 					// the chances of there being two images of this filesize are miniscule
 					// however, death rays etc! So:
 					// TODO: we need to look at comparing with sha256 value too
-					photoData[assetPath] = make(map[string]string)
-					photoData[assetPath]["copyright"] = image.Copyright()
-					photoData[assetPath]["description"] = image.Description()
+					photoData[assetName] = make(map[string]string)
+					photoData[assetName]["copyright"] = image.Copyright()
+					photoData[assetName]["description"] = image.Description()
 				}
 			}
 			assetsFound++
@@ -149,12 +147,11 @@ func scanExisting(targetPath string) (int, int) {
 		wpFound++
 		if _, ok := assetBySize[fileSize]; ok {
 			wpHash := cryptoSum(filePath)
-			for assetPath, assetHash := range assetBySize[fileSize] {
+			for assetName, assetHash := range assetBySize[fileSize] {
 				if wpHash == assetHash {
-					if toBeCopied[assetPath] {
-						toBeCopied[assetPath] = false
-						matchesFound++
-					}
+					toBeCopied[assetName] = false
+					matchesFound++
+					log.Printf("** %s matched with %s", assetName, file.Name())
 				}
 			}
 		}
@@ -169,13 +166,13 @@ func scanExisting(targetPath string) (int, int) {
 func copyNewAssets(targetPath, prefix string, smart bool) int {
 	copied := 0
 
-	for assetPath, tbc := range toBeCopied {
+	for assetName, tbc := range toBeCopied {
 		if tbc {
 			newPath := targetPath + "/"
-			newName := fileName[assetPath]
-			if _, ok := photoData[assetPath]; ok {
-				desc := photoData[assetPath]["description"]
-				cr := photoData[assetPath]["copyright"]
+			newName := assetName
+			if _, ok := photoData[assetName]; ok {
+				desc := photoData[assetName]["description"]
+				cr := photoData[assetName]["copyright"]
 				newName = newFilename(desc, cr)
 				if !smart {
 					newPath += prefix
@@ -183,18 +180,18 @@ func copyNewAssets(targetPath, prefix string, smart bool) int {
 			} else {
 				newPath += prefix
 			}
-			newName += "." + fileExt[assetPath]
+			newName += "." + fileExt[assetName]
 			newPath += newName
-			nbytes, err := copyFile(assetPath, newPath)
+			nbytes, err := copyFile(assetName, newPath)
 			if err == nil {
-				log.Printf("New image: %s (copied from %s)", newName, fileName[assetPath])
-				fmt.Printf("Copied %d bytes of %s to %s\n", nbytes, fileName[assetPath], newName)
+				log.Printf("New image: %s (copied from %s)", newName, assetName)
+				fmt.Printf("Copied %d bytes of %s to %s\n", nbytes, assetName, newName)
 				copied++
 			} else {
 				if nbytes == 0 {
 					fmt.Printf("Error copying file: %v\n", err)
 				} else {
-					fmt.Printf("Copied %d bytes of %s to %s; unable to set file time\n", nbytes, fileName[assetPath], newName)
+					fmt.Printf("Copied %d bytes of %s to %s; unable to set file time\n", nbytes, assetName, newName)
 				}
 			}
 		}
@@ -223,7 +220,8 @@ func newFilename(desc, cr string) string {
 	return desc + " " + cr
 }
 
-func copyFile(src, dst string) (int64, error) {
+func copyFile(sName, dst string) (int64, error) {
+	src := config.SourcePath + "/" + sName
 	file, err := os.Stat(src)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
…it directly as our key in most cases